### PR TITLE
Fix travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
+
 node_js:
-  - "node",
-  - "iojs",
-  - "6",
-  - "5",
+  - "node"
+  - "iojs"
+  - "6"
+  - "5"
   - "4"
+
 branches:
   only:
-  - master
-  - dev
+    - master
+    - dev


### PR DESCRIPTION
Travis seems to be [currently failing](https://travis-ci.org/ucbl/HyLAR-Reasoner/builds/155458862) with the following:

```
ERROR: An error occured while trying to parse your .travis.yml file.

Please make sure that the file is valid YAML.

http://lint.travis-ci.org can check your .travis.yml.

The log message was: Build config file had a parse error: did not find expected '-' indicator while parsing a block collection at line 3 column 3.
```

https://lint.travis-ci.org/ seems to say the above version is cool though. :shrug: