### PR TITLE
Fix a crash in recomputeClosure caused by failure to await the sm.ini…

### DIFF
--- a/hylar/hylar.js
+++ b/hylar/hylar.js
@@ -179,10 +179,10 @@ class Hylar {
         await this.recomputeClosure()
     }
 
-    clean() {
+    async clean() {
         this.dict = new Dictionary();
         this.sm = new TripleStorageManager();
-        this.sm.init();
+        await this.sm.init();
         this.persist()
     }
 


### PR DESCRIPTION
Failure to await the init function of the TripleStorageManager cases a crash when calling recomputeClosure.